### PR TITLE
chore: watch the directory instead of the file

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -532,23 +532,32 @@ function setupDisguisedPodmanSocketWatcher(
 ): extensionApi.FileSystemWatcher {
   // Monitor the socket file for any changes, creation or deletion
   // and trigger a change if that happens
-  const socketWatcher = extensionApi.fs.createFileSystemWatcher(socketFile);
+
+  // watch parent directory
+  const socketWatcher = extensionApi.fs.createFileSystemWatcher(path.dirname(socketFile));
 
   console.log('socket file:', socketFile);
 
-  socketWatcher.onDidChange(() => {
-    console.log('socket changed');
-    checkDisguisedPodmanSocket(provider);
+  // only trigger if the watched file is the socket file
+  const updateSocket = (uri: extensionApi.Uri) => {
+    if (uri.fsPath === socketFile) {
+      checkDisguisedPodmanSocket(provider);
+    }
+  };
+
+  socketWatcher.onDidChange(uri => {
+    console.log('socket changed', uri);
+    updateSocket(uri);
   });
 
-  socketWatcher.onDidCreate(() => {
-    console.log('socket created');
-    checkDisguisedPodmanSocket(provider);
+  socketWatcher.onDidCreate(uri => {
+    console.log('socket created', uri);
+    updateSocket(uri);
   });
 
-  socketWatcher.onDidDelete(() => {
-    console.log('socket deleted');
-    checkDisguisedPodmanSocket(provider);
+  socketWatcher.onDidDelete(uri => {
+    console.log('socket deleted', uri);
+    updateSocket(uri);
   });
 
   return socketWatcher;


### PR DESCRIPTION
### What does this PR do?
Watch /var/run/ directory (else we're mostly watching the real socket file and are missing changes like if symlink is deleted or recreated)


Change-Id: I81a5ae01dbc4fb37fb652a3e3ee678364bb46625
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
